### PR TITLE
check that assets exist in manifest before enqueueing them

### DIFF
--- a/generators/wp-plugin/templates/app/Services/Register.php.hbs
+++ b/generators/wp-plugin/templates/app/Services/Register.php.hbs
@@ -32,19 +32,21 @@ class Register extends ServiceProvider
     {
         $this->bud['collection']::make(['editor','public'])->each(
             function ($asset) {
-                wp_register_script(
-                    "{$asset}/script",
-                    $this->bud['manifest']->asset("{$asset}.js")->url(),
-                    $this->bud['manifest']->asset("{$asset}.json")->dependencies(),
-                    null,
-                );
+                $this->bud['manifest']->has("{$asset}.js")
+                    && wp_register_script(
+                        "{$asset}/script",
+                        $this->bud['manifest']->asset("{$asset}.js")->url(),
+                        $this->bud['manifest']->asset("{$asset}.json")->dependencies(),
+                        null,
+                    );
 
-                wp_register_style(
-                    "{$asset}/style",
-                    $this->bud['manifest']->asset("{$asset}.css")->url(),
-                    [],
-                    null,
-                );
+                $this->bud['manifest']->has("{$asset}.css")
+                    && wp_register_style(
+                        "{$asset}/style",
+                        $this->bud['manifest']->asset("{$asset}.css")->url(),
+                        [],
+                        null,
+                    );
             }
         );
     }


### PR DESCRIPTION
This fix uses the new `has` method from https://github.com/roots/bud-support/pull/1 to more safely enqueue assets and prevent issues like https://github.com/roots/bud/issues/64.