### PR TITLE
v.0.0.8

### DIFF
--- a/generators/wp-plugin/templates/app/Services/Register.php.hbs
+++ b/generators/wp-plugin/templates/app/Services/Register.php.hbs
@@ -1,6 +1,6 @@
 <?php
 
-namespace AcmeCo\Services;
+namespace {{pascalcase namespace}}\Services;
 
 use Roots\Bud\Services\ServiceProvider;
 use Roots\Bud\Container\Contracts\ContainerInterface;
@@ -53,7 +53,7 @@ class Register extends ServiceProvider
             : null;
 
         /**
-         * Inline manifest dependencies.
+         * Dependencies.
          *
          * @note If both `inlineManifest` and `dependencyManifest` are in use, the runtime manifest
          *       will have the dependencies asset manifest attached to it rather than the entrypoint.
@@ -82,7 +82,7 @@ class Register extends ServiceProvider
          */
         if ($runtime) {
             wp_register_script(
-                "{$asset}/script/runtime",
+                "{{lowercase namespace}}/{$asset}/script/runtime",
                 $runtime,
                 $runtimeDependencies,
                 null
@@ -94,7 +94,7 @@ class Register extends ServiceProvider
          */
         if ($script) {
             wp_register_script(
-                "{$asset}/script",
+                "{{lowercase namespace}}/{$asset}/script",
                 $script,
                 $scriptDependencies,
                 null
@@ -106,7 +106,7 @@ class Register extends ServiceProvider
          */
         if ($style) {
             wp_register_style(
-                "{$asset}/style",
+                "{{lowercase namespace}}/{$asset}/style",
                 $style,
                 [],
                 null
@@ -121,9 +121,9 @@ class Register extends ServiceProvider
      */
     public function adminInit(): void
     {
-        wp_enqueue_script('editor/script/runtime');
-        wp_enqueue_script('editor/script');
-        wp_enqueue_style('editor/style');
+        wp_enqueue_script('{{lowercase namespace}}/editor/script/runtime');
+        wp_enqueue_script('{{lowercase namespace}}/editor/script');
+        wp_enqueue_style('{{lowercase namespace}}/editor/style');
     }
 
     /**
@@ -133,8 +133,8 @@ class Register extends ServiceProvider
      */
     public function enqueueScripts(): void
     {
-        wp_enqueue_script('public/script/runtime');
-        wp_enqueue_script('public/script');
-        wp_enqueue_style('public/style');
+        wp_enqueue_script('{{lowercase namespace}}/public/script/runtime');
+        wp_enqueue_script('{{lowercase namespace}}/public/script');
+        wp_enqueue_style('{{lowercase namespace}}/public/style');
     }
 }

--- a/generators/wp-plugin/templates/app/Services/Register.php.hbs
+++ b/generators/wp-plugin/templates/app/Services/Register.php.hbs
@@ -1,12 +1,14 @@
 <?php
 
-namespace {{pascalcase namespace}}\Services;
+namespace AcmeCo\Services;
 
 use Roots\Bud\Services\ServiceProvider;
 use Roots\Bud\Container\Contracts\ContainerInterface;
 
 /**
- * Register client assets
+ * Register client assets.
+ *
+ * Enqueues
  */
 class Register extends ServiceProvider
 {
@@ -20,35 +22,96 @@ class Register extends ServiceProvider
       */
     public function boot(): void
     {
-        $this->registerAssets();
+        /** Vendored scripts. */
+        if ($this->bud['manifest']->has("vendor.js")) {
+            wp_register_script(
+                $this->bud['manifest']->asset("vendor.js")->url(),
+                [],
+                null
+            );
+        );
+
+        /**  Editor/admin bundle. */
+        $this->registerEntry('editor');
+
+        /** Public bundle. */
+        $this->registerEntry('public');
     }
 
     /**
-     * Register assets on init.
+     * Register entrypoint
      *
      * @return void
      */
-    public function registerAssets(): void
+    public function registerEntry($asset): void
     {
-        $this->bud['collection']::make(['editor','public'])->each(
-            function ($asset) {
-                $this->bud['manifest']->has("{$asset}.js")
-                    && wp_register_script(
-                        "{$asset}/script",
-                        $this->bud['manifest']->asset("{$asset}.js")->url(),
-                        $this->bud['manifest']->asset("{$asset}.json")->dependencies(),
-                        null,
-                    );
+        /**
+         * Inline manifest.
+         */
+        $runtime = $this->bud['manifest']->has("runtime/{$asset}.js")
+            ? $this->bud['manifest']->asset("runtime/{$asset}.js")->url()
+            : null;
 
-                $this->bud['manifest']->has("{$asset}.css")
-                    && wp_register_style(
-                        "{$asset}/style",
-                        $this->bud['manifest']->asset("{$asset}.css")->url(),
-                        [],
-                        null,
-                    );
-            }
-        );
+        /**
+         * Inline manifest dependencies.
+         *
+         * @note If both `inlineManifest` and `dependencyManifest` are in use, the runtime manifest
+         *       will have the dependencies asset manifest attached to it rather than the entrypoint.
+         */
+        $runtimeDependencies = $this->bud['manifest']->has("runtime/{$asset}.json")
+            ? $this->bud['manifest']->asset("runtime/{$asset}.json")->json()->dependencies
+            : [];
+        $scriptDependencies = $runtime ? ["{$asset}/script/runtime"] : [];
+
+        /**
+         * The entrypoint script.
+         */
+        $script = $this->bud['manifest']->has("{$asset}.js")
+            ? $this->bud['manifest']->asset("{$asset}.js")->url()
+            : null;
+
+        /**
+         * The entrypoint stylesheet.
+         */
+        $style = $this->bud['manifest']->has("{$asset}.css")
+            ? $this->bud['manifest']->asset("{$asset}.css")->url()
+            : null;
+
+        /**
+         * Register entrypoint runtime.
+         */
+        if ($runtime) {
+            wp_register_script(
+                "{$asset}/script/runtime",
+                $runtime,
+                $runtimeDependencies,
+                null
+            );
+        }
+
+        /**
+         * Register entrypoint script.
+         */
+        if ($script) {
+            wp_register_script(
+                "{$asset}/script",
+                $script,
+                $scriptDependencies,
+                null
+            );
+        }
+
+        /**
+         * Register entrypoint stylesheet.
+         */
+        if ($style) {
+            wp_register_style(
+                "{$asset}/style",
+                $style,
+                [],
+                null
+            );
+        }
     }
 
     /**
@@ -58,6 +121,7 @@ class Register extends ServiceProvider
      */
     public function adminInit(): void
     {
+        wp_enqueue_script('editor/script/runtime');
         wp_enqueue_script('editor/script');
         wp_enqueue_style('editor/style');
     }
@@ -69,6 +133,7 @@ class Register extends ServiceProvider
      */
     public function enqueueScripts(): void
     {
+        wp_enqueue_script('public/script/runtime');
         wp_enqueue_script('public/script');
         wp_enqueue_style('public/style');
     }

--- a/generators/wp-plugin/templates/bud.config.js.hbs
+++ b/generators/wp-plugin/templates/bud.config.js.hbs
@@ -1,53 +1,55 @@
-const bud = require('@roots/budpack');
-
-/*
- |--------------------------------------------------------------------------
- | Project configuration
- |--------------------------------------------------------------------------
- |
- | Add assets you wish to enqueue in the context of the WordPress admin
- | and editor interfaces.
- |
+/**
+ * This object contains a ton of tools to set up the build
+ * for your application.
  */
+const bud = require('@roots/budpack')
 
-bud.projectPath(__dirname)
+/**
+ * Set project asset paths.
+ */
+bud
   .srcPath('src')
   .distPath('dist')
-  .alias({
-    '@blocks': bud.src('blocks'),
-    '@components': bud.src('components'),
-  })
-  .browserSync({
-    enabled: true,
-    proxy: '{{ proxyHost }}',
-  })
 
-/*
- |--------------------------------------------------------------------------
- | Editor assets
- |--------------------------------------------------------------------------
- |
- | Add assets you to enqueue in the context of the WordPress admin
- | and editor interfaces.
- |
+/**
+ * Alias project directories.
  */
+bud.alias({
+  '@blocks': bud.src('blocks'),
+  '@components': bud.src('components'),
+})
 
-bud.entry('editor', [
-  bud.src('entry-editor.js'),
-])
-
-/*
- |--------------------------------------------------------------------------
- | Public assets
- |--------------------------------------------------------------------------
- |
- | Add assets to be enqueued on outward-facing site content in addition to
- | admin and editor interfaces.
- |
+/**
+ * Live reload configuration.
  */
+bud.sync({
+  proxy: 'http://bud-sandbox.valet',
+  port: 3010,
+})
 
-bud.entry('public', [
-  bud.src('entry-public.js'),
-])
+/**
+ * Produce asset bundles.
+ */
+bud
+  .bundle('editor', [
+    bud.src('entry-editor.js'),
+  ])
+  .bundle('public', [
+    bud.src('entry-public.js'),
+  ])
+  .dependencyManifest()
+  .inlineManifest()
+  .vendor()
+  .hash();
 
+/**
+ * Configure transpilers.
+ */
+bud
+  .babel(bud.preset('babel/preset-wp'))
+  .postCss(bud.preset('postcss'))
+
+/**
+ * Export finalize configuration.
+ */
 module.exports = bud

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-generators",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "git://github.com/roots/bud-generators.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-generators",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type": "git",
     "url": "git://github.com/roots/bud-generators.git"


### PR DESCRIPTION
v.0.0.7: 

- Recent changes to roots/bud-support required updates to the generated webpack config (js) and `Register` service (php).

v.0.0.8:
- fixes a small oversight (had already published to npm, so a new version is needed.)
